### PR TITLE
Styles the search box to blend with the sidebar

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -79,3 +79,25 @@ figure.icon {
   }
 }
 
+.autocomplete-suggestions {
+  background: #ebe6f9;
+  outline: none;
+  border: 1px solid #322A38;
+  border-top: 0px solid transparent;
+  border-radius: 0 6px 6px 6px;
+}
+
+.autocomplete-suggestions::-webkit-scrollbar {
+  width: 12px;
+}
+
+.autocomplete-suggestions::-webkit-scrollbar-thumb {
+  background: #322A38;
+  border-radius: 6px;
+}
+
+.autocomplete-suggestions .autocomplete-suggestion.selected {
+  background: #322A38;
+}
+
+


### PR DESCRIPTION
Please test locally, given that some site assets (search box related), do not play well with the way Netlify's previews rely on subdomains.